### PR TITLE
不要な修正を元に戻す

### DIFF
--- a/src/core/embedders/CustomFontEmbedder.ts
+++ b/src/core/embedders/CustomFontEmbedder.ts
@@ -141,18 +141,16 @@ class CustomFontEmbedder {
   protected async embedCIDFontDict(context: PDFContext): Promise<PDFRef> {
     const fontDescriptorRef = await this.embedFontDescriptor(context);
 
-    const cidSystemInfo = context.obj({
-      Registry: PDFString.of('Adobe'),
-      Ordering: PDFString.of('Identity'),
-      Supplement: 0,
-    });
-
     const cidFontDict = context.obj({
       Type: 'Font',
       Subtype: this.isCFF() ? 'CIDFontType0' : 'CIDFontType2',
       CIDToGIDMap: 'Identity',
       BaseFont: this.baseFontName,
-      CIDSystemInfo: cidSystemInfo,
+      CIDSystemInfo: {
+        Registry: PDFString.of('Adobe'),
+        Ordering: PDFString.of('Identity'),
+        Supplement: 0,
+      },
       FontDescriptor: fontDescriptorRef,
       W: this.computeWidths(),
     });


### PR DESCRIPTION
src/core/embedders/CustomFontEmbedder.ts の改修が無くてもパスワードありPDF表示空白の不具合は解決したため、元に戻す
